### PR TITLE
Add a possibility to explicitly override the soname during initialization

### DIFF
--- a/generate-wrapper.py
+++ b/generate-wrapper.py
@@ -149,10 +149,10 @@ def write_implementation(filename, soname, sysincludes, initname, functions, sym
         for sym_definition in sym_definitions:
             file.write(f"{sym_definition}\n")
 
-        file.write(f"int initialize_{initname}(int verbose) {{\n")
+        file.write(f"int initialize_{initname}_explicit(const char* soname, int verbose) {{\n")
         file.write("  void *handle;\n")
         file.write("  char *error;\n")
-        file.write(f"  handle = dlopen(\"{soname}\", RTLD_LAZY);\n")
+        file.write(f"  handle = dlopen(soname, RTLD_LAZY);\n")
         file.write("  if (!handle) {\n")
         file.write("    if (verbose) {\n")
         file.write("      fprintf(stderr, \"%s\\n\", dlerror());\n")
@@ -175,6 +175,10 @@ def write_implementation(filename, soname, sysincludes, initname, functions, sym
         file.write("return 0;\n");
         file.write("}\n")
 
+        file.write(f"int initialize_{initname}(int verbose) {{\n")
+        file.write(f"  return initialize_{initname}_explicit(\"{soname}\", verbose);\n")
+        file.write("}\n")
+
 def write_header(filename, sysincludes, initname, functions, sym_definitions):
     with open(filename, 'w') as file:
         file.write(f"#ifndef DYLIBLOAD_WRAPPER_{initname.upper()}\n")
@@ -191,6 +195,7 @@ def write_header(filename, sysincludes, initname, functions, sym_definitions):
             file.write(f"extern {sym_definition}\n")
 
         file.write(f"int initialize_{initname}(int verbose);\n")
+        file.write(f"int initialize_{initname}_explicit(const char* soname, int verbose);\n")
 
         file.write("#ifdef __cplusplus\n")
         file.write("}\n")


### PR DESCRIPTION
For purposes of mock testing, it would be very useful if I could explicitly override the .so name when initializing the dynamic loader.

This PR keeps all the existing behavior and initialize_{library} still works as before. But it also introduces a initialize_{library}_explicit where the caller can explicitly pass the .so name.

Please consider merging this as I think it adds some useful functionality while having low impact/risk.